### PR TITLE
Fix metrics card padding on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,7 @@
             
             .metrics-grid {
                 grid-template-columns: repeat(2, 1fr);
+                gap: var(--space-lg);
             }
         }
         


### PR DESCRIPTION
## Summary
- even out padding between metrics cards on mobile view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685830c5cfb88332998bf659d1713cc4