### PR TITLE
Update role titles to AI Architect

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>About | Ziyad Mir - Principal IC SWE</title>
+    <title>About | Ziyad Mir - AI Architect, AI-for-Work</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="/shared-styles.css" rel="stylesheet">
     <style type="text/css">
@@ -260,7 +260,7 @@
                         <div class="text-gray-700">
                             <div class="company-header">
                                 <img src="/images/companies/coupang.png" alt="Coupang" class="company-logo">
-                                <p class="font-semibold">Coupang, Principal Engineer</p>
+                                <p class="font-semibold">Coupang, AI Architect - AI-for-Work</p>
                             </div>
                             <p class="mb-2 text-sm">Mountain View, CA</p>
                             <ul class="list-disc pl-5 space-y-1 text-sm">
@@ -286,7 +286,7 @@
                             </div>
                             <p class="mb-2 text-sm">Zurich, Switzerland & San Francisco, CA</p>
                             <ul class="list-disc pl-5 space-y-1 text-sm">
-                                <li>Principal IC for Youtube Select (multi-billion dollar ARR product)</li>
+                                <li>AI Architect for YouTube Select (multi-billion dollar ARR product)</li>
                                 <li>Led Youtube Flash: Moment-Level Youtube Ads (hundreds of millions in incremental ARR)</li>
                                 <li>Launched Youtube Select for Shorts, competing with TikTok Pulse</li>
                                 <li>Developed BrandShift metrics for Brand Identity</li>

--- a/blog.html
+++ b/blog.html
@@ -134,7 +134,7 @@
                 <!-- AI-for-Work Series -->
                 <div class="series-card">
                     <div class="series-header">
-                        <h2 class="series-title">AI-for-Work: A Principal Engineer's Guide to Enterprise AI</h2>
+                        <h2 class="series-title">AI-for-Work: An AI Architect's Guide to Enterprise AI</h2>
                         <p class="series-meta">6-Part Series • December 2024 - May 2025</p>
                     </div>
                     <div class="series-content">

--- a/blog/ai-for-work-part-5-knowledge-preservation.html
+++ b/blog/ai-for-work-part-5-knowledge-preservation.html
@@ -418,7 +418,7 @@
             </div>
 
             <div class="case-study-box">
-                <p><em>"Our AI agents now have access to years of tribal knowledge. They give much better architectural recommendations."</em> - Principal Engineer</p>
+                <p><em>"Our AI agents now have access to years of tribal knowledge. They give much better architectural recommendations."</em> - AI Architect</p>
             </div>
 
             <h2>Implementation Strategy</h2>

--- a/blog/ai-for-work-series-index.html
+++ b/blog/ai-for-work-series-index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI-for-Work: A Principal Engineer's Pragmatic Guide | Ziyad Mir</title>
+    <title>AI-for-Work: An AI Architect's Pragmatic Guide | Ziyad Mir</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="/shared-styles.css" rel="stylesheet">
     <style type="text/css">
@@ -100,7 +100,7 @@
 
     <main class="container mx-auto px-4 py-8 flex-grow">
         <article class="blog-content">
-            <h1 class="text-3xl font-bold text-primary mb-3">AI-for-Work: A Principal Engineer's Pragmatic Guide to AI Deployment in Large Enterprises</h1>
+            <h1 class="text-3xl font-bold text-primary mb-3">AI-for-Work: An AI Architect's Pragmatic Guide to AI Deployment in Large Enterprises</h1>
             <p class="text-gray-500 text-sm mb-4">April 15, 2025 · Series Overview</p>
             
             <div class="flex flex-wrap gap-2 mb-6">
@@ -172,7 +172,7 @@
 
             <h2>Who This Series Is For</h2>
             <ul>
-                <li><strong>Principal Engineers</strong> and <strong>Staff Engineers</strong> tasked with AI strategy</li>
+                <li><strong>AI Architects</strong> and <strong>Staff Engineers</strong> tasked with AI strategy</li>
                 <li><strong>Engineering Managers</strong> looking to boost team productivity</li>
                 <li><strong>Platform Engineers</strong> building internal AI infrastructure</li>
                 <li><strong>Security Engineers</strong> concerned about AI governance</li>

--- a/projects/coupang-ai-work.html
+++ b/projects/coupang-ai-work.html
@@ -361,7 +361,7 @@
             <div class="highlight-box mb-8">
                 <p>Leading Coupang's enterprise-wide AI transformation, fundamentally changing how 2,500+ engineers work through systematic AI tool deployment, infrastructure development, and cultural change. This initiative has achieved 30%+ productivity gains and established Coupang as a leader in enterprise AI adoption.</p>
                 <div class="highlight-box-meta">
-                    <span>Principal Engineer</span>
+                    <span>AI Architect, AI-for-Work</span>
                     <span>2024 - Present</span>
                     <span>Mountain View, CA</span>
                 </div>
@@ -369,7 +369,7 @@
             
             <h2>Project Overview</h2>
             <p>
-                As Principal Engineer at Coupang, I'm leading the AI-for-Work initiative - a comprehensive transformation of how engineering work is done at enterprise scale. This isn't just about deploying AI tools; it's about fundamentally reimagining engineering workflows, building critical infrastructure, and driving cultural change across a 2,500+ person engineering organization.
+                As the AI Architect for Coupang's AI-for-Work initiative, I'm leading a comprehensive transformation of how engineering work is done at enterprise scale. This isn't just about deploying AI tools; it's about fundamentally reimagining engineering workflows, building critical infrastructure, and driving cultural change across a 2,500+ person engineering organization.
             </p>
             
             <p>
@@ -799,7 +799,7 @@
             <h2>My Role & Leadership</h2>
             
             <p>
-                As Principal Engineer leading this initiative, I:
+                As the AI Architect leading this initiative, I:
             </p>
             
             <ul>

--- a/projects/youtube-flash.html
+++ b/projects/youtube-flash.html
@@ -185,7 +185,7 @@
                     <div class="highlight-box-meta">
                         <span class="mr-4">2022-Present</span>
                         <span class="mr-4">Hundreds of Millions in Incremental ARR</span>
-                        <span class="mr-4">Principal IC</span>
+                        <span class="mr-4">AI Architect</span>
                     </div>
                     <div class="mt-2">
                         <span class="highlight-box-tag">Multimodal ML</span>
@@ -324,7 +324,7 @@
                     <h2>My Role & Contributions</h2>
                     
                     <p>
-                        As the Principal IC for YouTube Flash, I:
+                        As the AI Architect for YouTube Flash, I:
                     </p>
                     
                     <ul>

--- a/projects/youtube-select-shorts.html
+++ b/projects/youtube-select-shorts.html
@@ -186,7 +186,7 @@
                 <div class="highlight-box-meta">
                     <span class="mr-4">2021-Present</span>
                     <span class="mr-4">Hundreds of Millions in Incremental ARR</span>
-                    <span class="mr-4">Principal IC</span>
+                    <span class="mr-4">AI Architect</span>
                 </div>
                 <div class="mt-2">
                     <span class="highlight-box-tag">Short-form Content</span>


### PR DESCRIPTION
## Summary
- update career titles across the site from "Principal Engineer" or "Principal IC" to "AI Architect"
- adjust references in project and blog pages

## Testing
- `grep -Ri "Principal" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_68587d9029c08332a43b9059018f1230