### PR TITLE
Fix hero spacing and center metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
             display: flex;
             align-items: center;
             position: relative;
+            padding-bottom: var(--space-3xl);
         }
         
         .hero-content {
@@ -166,6 +167,7 @@
             gap: var(--space-2xl);
             margin-bottom: var(--space-3xl);
             text-align: center;
+            place-items: center;
         }
         
         .metric-item {
@@ -175,6 +177,11 @@
             border-radius: var(--radius-lg);
             transition: all var(--transition-base);
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: var(--space-xs);
         }
         
         .metric-item:hover {


### PR DESCRIPTION
## Summary
- add bottom padding to hero so metrics don't bump into it
- center metric cards visually and evenly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858ddde02048332a34bbb26768840c9