### PR TITLE
Fix proof-of-concept blog layout

### DIFF
--- a/blog/ai-first-workflow-poc.html
+++ b/blog/ai-first-workflow-poc.html
@@ -29,10 +29,12 @@
         }
     </style>
 </head>
-<body>
+<body class="bg-gray-50 text-gray-800 flex flex-col min-h-screen">
+    <!-- Shared header will be loaded here -->
     <div id="shared-header"></div>
-    <main class="blog-content py-8">
-        <article>
+
+    <main class="container mx-auto px-4 py-8 flex-grow">
+        <article class="blog-content">
             <h1 class="text-3xl font-bold mb-4">Proof of Concept: Coding an MCP Client with Claude</h1>
             <p>Yesterday I put Claude Code Opus 4 through its paces by asking it to build a small repository from scratch: <a href="https://github.com/ziyadmir/nba-player-stats-mcp" class="text-blue-600 hover:text-blue-800">nba-player-stats-mcp</a>. The goal was simple—answer questions like “How many rebounds did LeBron James get per game in 2023?” via a Model Context Protocol (MCP) client.</p>
 


### PR DESCRIPTION
## Summary
- wrap proof-of-concept blog post in site container
- apply standard body classes for consistent padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685950eb74988332a2afadcf2ff468ae