### PR TITLE
Add AI and Layoffs series

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -178,6 +178,24 @@
                                 </svg>
                             </a>
                         </div>
+                </div>
+                </div>
+
+                <!-- AI and Layoffs Series -->
+                <div class="series-card">
+                    <div class="series-header">
+                        <h2 class="series-title">AI and Layoffs</h2>
+                        <p class="series-meta">Ongoing Series • Started June 2025</p>
+                    </div>
+                    <div class="series-content">
+                        <a href="/blog/future-of-work-ai-guidance.html" class="post-item">
+                            <h3 class="post-title">The Future of Work: AI Guidance and the New Engineering Paradigm</h3>
+                            <p class="post-date">June 24, 2025</p>
+                        </a>
+                        <a href="/blog/ai-layoffs-capability-gradient.html" class="post-item">
+                            <h3 class="post-title">AI, Layoffs, and the Capability Gradient</h3>
+                            <p class="post-date">July 8, 2025</p>
+                        </a>
                     </div>
                 </div>
 
@@ -299,10 +317,6 @@
                             <h3 class="post-title">Proof of Concept: Coding an MCP Client with Claude</h3>
                             <p class="post-date">July 2, 2025</p>
                         </a>
-                        <a href="/blog/future-of-work-ai-guidance.html" class="post-item">
-                            <h3 class="post-title">The Future of Work: AI Guidance and the New Engineering Paradigm</h3>
-                            <p class="post-date">June 24, 2025</p>
-                        </a>
                         <a href="/blog/two-tiered-internet-ai-content.html" class="post-item">
                             <h3 class="post-title">The Coming Two-Tiered Internet</h3>
                             <p class="post-date">July 2, 2025</p>
@@ -334,10 +348,6 @@
                         <a href="/blog/generative-worlds-human-exploration.html" class="post-item">
                             <h3 class="post-title">Generative Worlds: Why Humans Will Live in AI-Created Realities</h3>
                             <p class="post-date">July 5, 2025</p>
-                        </a>
-                        <a href="/blog/ai-layoffs-capability-gradient.html" class="post-item">
-                            <h3 class="post-title">AI, Layoffs, and the Capability Gradient</h3>
-                            <p class="post-date">July 8, 2025</p>
                         </a>
                         <div class="post-item">
                             <p class="coming-soon">More posts coming soon...</p>


### PR DESCRIPTION
## Summary
- add a new "AI and Layoffs" series after the "AI-for-Work" series
- move two posts about layoffs and resourcing from the Strategy & Philosophy series into the new section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dd1cb086883329202ac720a864955